### PR TITLE
stop sending page html to stdout

### DIFF
--- a/lib/phantom/script.js
+++ b/lib/phantom/script.js
@@ -110,8 +110,7 @@ function generateAfterScreenshot(options) {
 
   setTimeout(function () {
     window.callPhantom({
-      status: options.STATUS_INLINED_CSS_DONE,
-      html: document.documentElement.innerHTML
+      status: options.STATUS_INLINED_CSS_DONE
     });
   }, options.renderDelay);
 }
@@ -132,9 +131,6 @@ page.onResourceRequested = function (requestData, request) {
 };
 
 page.onCallback = function (data) {
-  if (data.html) {
-    system.stdout.write(data.html);
-  }
   if (data.status === STATUS_INLINED_CSS_DONE) {
     renderScreenshot('after');
     phantomExit(0);

--- a/src/phantom/script.js
+++ b/src/phantom/script.js
@@ -109,8 +109,7 @@ function generateAfterScreenshot (options) {
 
   setTimeout(function () {
     window.callPhantom({
-      status: options.STATUS_INLINED_CSS_DONE,
-      html: document.documentElement.innerHTML
+      status: options.STATUS_INLINED_CSS_DONE
     })
   }, options.renderDelay)
 }
@@ -131,9 +130,6 @@ page.onResourceRequested = function (requestData, request) {
 }
 
 page.onCallback = function (data) {
-  if (data.html) {
-    system.stdout.write(data.html)
-  }
   if (data.status === STATUS_INLINED_CSS_DONE) {
     renderScreenshot('after')
     phantomExit(0)


### PR DESCRIPTION
never used, and causing issues on osx,
where the 'exit' event never got dispatched if there was
stdout messages going out but with no listener for them.
